### PR TITLE
Install tssilomon into bin directory

### DIFF
--- a/recipes-extras/ts4900-utils/ts4900-utils.bb
+++ b/recipes-extras/ts4900-utils/ts4900-utils.bb
@@ -19,6 +19,7 @@ do_install_append() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
         install -d ${D}${systemd_unitdir}/system
         install -m 0644 ${WORKDIR}/tssilomon.service ${D}${systemd_unitdir}/system
+        install -m 0755 ${S}/script/tssilomon ${D}${bindir}
 
         sed -i -e 's#@BINDIR@#${bindir}#g' ${D}${systemd_unitdir}/system/tssilomon.service
     fi


### PR DESCRIPTION
I had to fork the meta-ts layer to include the tssilomon script in /usr/bin in the Yocto image.